### PR TITLE
修复心跳包没有 stat 字段导致的异常

### DIFF
--- a/src/EleCho.GoCqHttpSdk/DataStructure/CqStatus.cs
+++ b/src/EleCho.GoCqHttpSdk/DataStructure/CqStatus.cs
@@ -19,9 +19,9 @@ namespace EleCho.GoCqHttpSdk
             AppGood = model.app_good;
             Online = model.online;
             Good = model.good;
-            Statistics = new CqStatusStatistics(model.stat);
+            Statistics = model.stat == null ? new CqStatusStatistics() : new CqStatusStatistics(model.stat);
         }
-        
+
         /// <summary>
         /// 程序初始化完成
         /// </summary>
@@ -51,7 +51,6 @@ namespace EleCho.GoCqHttpSdk
         /// 状态良好
         /// </summary>
         public bool Good { get; }
-
 
         /// <summary>
         /// 统计信息


### PR DESCRIPTION
## 问题

在 Lagrange.Core 的实现中，心跳包 的 `status` 字段没有包含 `stat`， 导致消息处理线程挂掉，无法处理后续消息。

## 修复方式

如果不包含 `stat`，就设置一个默认的 `CqStatusStatistics`。

## 相关信息

- https://github.com/LagrangeDev/Lagrange.Core