### PR TITLE
新接口 CqNoticeEssencePostContext.GroupId和一些其他的东西

### DIFF
--- a/src/EleCho.GoCqHttpSdk.CommandExecuting/EleCho.GoCqHttpSdk.CommandExecuting.csproj
+++ b/src/EleCho.GoCqHttpSdk.CommandExecuting/EleCho.GoCqHttpSdk.CommandExecuting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net7.0;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <Version>1.0.7</Version>

--- a/src/EleCho.GoCqHttpSdk.MessageMatching/EleCho.GoCqHttpSdk.MessageMatching.csproj
+++ b/src/EleCho.GoCqHttpSdk.MessageMatching/EleCho.GoCqHttpSdk.MessageMatching.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;net7.0;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <Version>1.0.6</Version>

--- a/src/EleCho.GoCqHttpSdk/CqRWsSession.cs
+++ b/src/EleCho.GoCqHttpSdk/CqRWsSession.cs
@@ -13,7 +13,7 @@ namespace EleCho.GoCqHttpSdk
     /// <summary>
     /// 反向 WebSocket 会话
     /// </summary>
-    public class CqRWsSession : CqSession, ICqActionSession, ICqPostSession, IDisposable
+    public class CqRWsSession : CqSession, ICqActionAndPostSession, ICqActionSession, ICqPostSession, IDisposable
     {
         private readonly Uri baseUri;
         private readonly int bufferSize;

--- a/src/EleCho.GoCqHttpSdk/CqRWsSession.cs
+++ b/src/EleCho.GoCqHttpSdk/CqRWsSession.cs
@@ -13,7 +13,7 @@ namespace EleCho.GoCqHttpSdk
     /// <summary>
     /// 反向 WebSocket 会话
     /// </summary>
-    public class CqRWsSession : CqSession, ICqActionAndPostSession, ICqActionSession, ICqPostSession, IDisposable
+    public class CqRWsSession : CqSession, ICqActionSession, ICqPostSession, IDisposable
     {
         private readonly Uri baseUri;
         private readonly int bufferSize;

--- a/src/EleCho.GoCqHttpSdk/CqWsSession.cs
+++ b/src/EleCho.GoCqHttpSdk/CqWsSession.cs
@@ -19,7 +19,7 @@ namespace EleCho.GoCqHttpSdk
     /// 正向 WebSocket 会话
     /// 可处理上报, 以及发送 Action
     /// </summary>
-    public class CqWsSession : CqSession, ICqActionAndPostSession, ICqPostSession, ICqActionSession, IDisposable
+    public class CqWsSession : CqSession, ICqPostSession, ICqActionSession, IDisposable
     {
         /// <summary>
         /// 基地址

--- a/src/EleCho.GoCqHttpSdk/CqWsSession.cs
+++ b/src/EleCho.GoCqHttpSdk/CqWsSession.cs
@@ -19,7 +19,7 @@ namespace EleCho.GoCqHttpSdk
     /// 正向 WebSocket 会话
     /// 可处理上报, 以及发送 Action
     /// </summary>
-    public class CqWsSession : CqSession, ICqPostSession, ICqActionSession, IDisposable
+    public class CqWsSession : CqSession, ICqActionAndPostSession, ICqPostSession, ICqActionSession, IDisposable
     {
         /// <summary>
         /// 基地址

--- a/src/EleCho.GoCqHttpSdk/EleCho.GoCqHttpSdk.csproj
+++ b/src/EleCho.GoCqHttpSdk/EleCho.GoCqHttpSdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net6.0;net7.0;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <Authors>SlimeNull</Authors>
@@ -30,11 +30,7 @@
     <None Remove="Temp\**" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
-    <PackageReference Include="System.Net.Http" Version="*" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net462' Or '$(TargetFramework)'=='netstandard2.0' Or '$(TargetFramework)'=='netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="System.Text.Json" Version="*" />
   </ItemGroup>
 

--- a/src/EleCho.GoCqHttpSdk/ICqActionAndPostSession.cs
+++ b/src/EleCho.GoCqHttpSdk/ICqActionAndPostSession.cs
@@ -1,6 +1,6 @@
 ﻿namespace EleCho.GoCqHttpSdk
 {
-    internal interface ICqActionAndPostSession : ICqPostSession, ICqActionSession
+    public interface ICqActionAndPostSession : ICqPostSession, ICqActionSession
     {
     }
 }

--- a/src/EleCho.GoCqHttpSdk/ICqActionAndPostSession.cs
+++ b/src/EleCho.GoCqHttpSdk/ICqActionAndPostSession.cs
@@ -1,6 +1,0 @@
-﻿namespace EleCho.GoCqHttpSdk
-{
-    public interface ICqActionAndPostSession : ICqPostSession, ICqActionSession
-    {
-    }
-}

--- a/src/EleCho.GoCqHttpSdk/ICqActionAndPostSession.cs
+++ b/src/EleCho.GoCqHttpSdk/ICqActionAndPostSession.cs
@@ -1,0 +1,6 @@
+﻿namespace EleCho.GoCqHttpSdk
+{
+    internal interface ICqActionAndPostSession : ICqPostSession, ICqActionSession
+    {
+    }
+}

--- a/src/EleCho.GoCqHttpSdk/Post/Base/CqMessagePostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/Base/CqMessagePostContext.cs
@@ -66,6 +66,7 @@ namespace EleCho.GoCqHttpSdk.Post
             Message = new CqMessage(msgModel.message.Select(CqMsg.FromModel));
             RawMessage = msgModel.raw_message;
             Font = msgModel.font;
+            Sender = new CqMessageSender(msgModel.sender);
         }
     }
 }

--- a/src/EleCho.GoCqHttpSdk/Post/Base/CqMessagePostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/Base/CqMessagePostContext.cs
@@ -26,27 +26,33 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 消息 ID
         /// </summary>
-        public long MessageId { get; set; }
+        public long MessageId { get; internal set; }
 
         /// <summary>
         /// 用户 ID
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
+
+        /// <summary>
+        /// 发送者
+        /// </summary>
+        //对我没初始化但这是个abstract class并且派生类型都初始化了这个所以没问题...吧... -by gdr2333
+        public CqMessageSender Sender { get; internal set; } = new CqMessageSender();
 
         /// <summary>
         /// 消息实例
         /// </summary>
-        public CqMessage Message { get; set; } = new CqMessage(0);
+        public CqMessage Message { get; internal set; } = new CqMessage(0);
 
         /// <summary>
         /// 原始消息 (CQ 码)
         /// </summary>
-        public string RawMessage { get; set; } = string.Empty;
+        public string RawMessage { get; internal set; } = string.Empty;
 
         /// <summary>
         /// 字体
         /// </summary>
-        public int Font { get; set; }
+        public int Font { get; internal set; }
 
         internal override void ReadModel(CqPostModel model)
         {

--- a/src/EleCho.GoCqHttpSdk/Post/Base/CqPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/Base/CqPostContext.cs
@@ -29,12 +29,12 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 机器人 QQ ID
         /// </summary>
-        public long SelfId { get; set; }
+        public long SelfId { get; internal set; }
 
         /// <summary>
         /// 上报时间
         /// </summary>
-        public DateTime Time { get; set; }
+        public DateTime Time { get; internal set; }
 
         internal abstract object? QuickOperationModel { get; }
 

--- a/src/EleCho.GoCqHttpSdk/Post/Base/CqSelfMessagePostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/Base/CqSelfMessagePostContext.cs
@@ -22,27 +22,27 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 消息 ID
         /// </summary>
-        public long MessageId { get; set; }
+        public long MessageId { get; internal set; }
 
         /// <summary>
         /// 用户 ID
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// 消息实例
         /// </summary>
-        public CqMessage Message { get; set; } = new CqMessage(0);
+        public CqMessage Message { get; internal set; } = new CqMessage(0);
 
         /// <summary>
         /// 原始消息 (CQ 码)
         /// </summary>
-        public string RawMessage { get; set; } = string.Empty;
+        public string RawMessage { get; internal set; } = string.Empty;
 
         /// <summary>
         /// 字体
         /// </summary>
-        public int Font { get; set; }
+        public int Font { get; internal set; }
 
         internal override void ReadModel(CqPostModel model)
         {

--- a/src/EleCho.GoCqHttpSdk/Post/CqClientStatusChangedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqClientStatusChangedPostContext.cs
@@ -19,12 +19,12 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 是否在线
         /// </summary>
-        public bool IsOnline { get; set; }
+        public bool IsOnline { get; internal set; }
 
         /// <summary>
         /// 客户端
         /// </summary>
-        public CqDevice Client { get; set; } = new CqDevice();
+        public CqDevice Client { get; internal set; } = new CqDevice();
         
         internal override object? QuickOperationModel => null;
         internal override void ReadModel(CqPostModel model)

--- a/src/EleCho.GoCqHttpSdk/Post/CqFriendAddedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqFriendAddedPostContext.cs
@@ -16,7 +16,7 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         internal CqFriendAddedPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqFriendMessageRecalledPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqFriendMessageRecalledPostContext.cs
@@ -16,12 +16,12 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// 消息 ID
         /// </summary>
-        public long MessageId { get; set; }
+        public long MessageId { get; internal set; }
 
         internal CqFriendMessageRecalledPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqFriendRequestPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqFriendRequestPostContext.cs
@@ -17,17 +17,17 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// 验证消息
         /// </summary>
-        public string Comment { get; set; } = string.Empty;
+        public string Comment { get; internal set; } = string.Empty;
 
         /// <summary>
         /// 请求标志 (用来处理请求)
         /// </summary>
-        public string Flag { get; set; } = string.Empty;
+        public string Flag { get; internal set; } = string.Empty;
         
         internal CqFriendRequestPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupAdminChangedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupAdminChangedPostContext.cs
@@ -1,4 +1,5 @@
 ﻿
+using EleCho.GoCqHttpSdk.Post.Interface;
 using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
@@ -6,7 +7,7 @@ namespace EleCho.GoCqHttpSdk.Post
     /// <summary>
     /// 群管理员变更上报上下文
     /// </summary>
-    public record class CqGroupAdministratorChangedPostContext : CqNoticePostContext
+    public record class CqGroupAdministratorChangedPostContext : CqNoticePostContext, IGroupPostContext
     {
         /// <summary>
         /// 通知类型: 群管理员
@@ -16,17 +17,17 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 变更类型
         /// </summary>
-        public CqGroupAdminChangeType ChangeType { get; set; }
+        public CqGroupAdminChangeType ChangeType { get; internal set; }
 
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         internal CqGroupAdministratorChangedPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupEssenceChangedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupEssenceChangedPostContext.cs
@@ -1,4 +1,5 @@
 ﻿
+using EleCho.GoCqHttpSdk.Post.Interface;
 using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
@@ -6,7 +7,7 @@ namespace EleCho.GoCqHttpSdk.Post
     /// <summary>
     /// 群精华消息变更上报上下文
     /// </summary>
-    public record class CqGroupEssenceChangedPostContext : CqNoticePostContext
+    public record class CqGroupEssenceChangedPostContext : CqNoticePostContext, IGroupPostContext
     {
         internal CqGroupEssenceChangedPostContext() { }
 
@@ -18,22 +19,27 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 变更类型
         /// </summary>
-        public CqEssenceChangeType ChangeType { get; set; }
+        public CqEssenceChangeType ChangeType { get; internal set; }
 
         /// <summary>
         /// 消息发送者 QQ
         /// </summary>
-        public long SenderId { get; set; }
+        public long SenderId { get; internal set; }
 
         /// <summary>
         /// 操作者 QQ
         /// </summary>
-        public long OperatorId { get; set; }
+        public long OperatorId { get; internal set; }
 
         /// <summary>
         /// 消息 ID
         /// </summary>
-        public long MessageId { get; set; }
+        public long MessageId { get; internal set; }
+
+        /// <summary>
+        /// 群号
+        /// </summary>
+        public long GroupId { get; internal set; }
 
         internal override object? QuickOperationModel => null;
         internal override void ReadModel(CqPostModel model)
@@ -47,6 +53,7 @@ namespace EleCho.GoCqHttpSdk.Post
             SenderId = noticeModel.sender_id;
             OperatorId = noticeModel.operator_id;
             MessageId = noticeModel.message_id;
+            GroupId = noticeModel.group_id;
         }
     }
 }

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupFileUploadedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupFileUploadedPostContext.cs
@@ -1,5 +1,5 @@
 ﻿using EleCho.GoCqHttpSdk;
-
+using EleCho.GoCqHttpSdk.Post.Interface;
 using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
@@ -7,7 +7,7 @@ namespace EleCho.GoCqHttpSdk.Post
     /// <summary>
     /// 群文件上传上报上下文
     /// </summary>
-    public record class CqGroupFileUploadedPostContext : CqNoticePostContext
+    public record class CqGroupFileUploadedPostContext : CqNoticePostContext, IGroupPostContext
     {
         /// <summary>
         /// 通知类型: 群文件上传
@@ -17,17 +17,17 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
         
         /// <summary>
         /// 群文件
         /// </summary>
-        public CqGroupUploadedFile File { get; set; } = new CqGroupUploadedFile();
+        public CqGroupUploadedFile File { get; internal set; } = new CqGroupUploadedFile();
         
         internal CqGroupFileUploadedPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupLuckyKingNoticedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupLuckyKingNoticedPostContext.cs
@@ -16,17 +16,17 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 用户 QQ (红包发送者 QQ)
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
         
         /// <summary>
         /// 目标 QQ (运气王 QQ)
         /// </summary>
-        public long TargetId { get; set; }
+        public long TargetId { get; internal set; }
 
 
         internal CqGroupLuckyKingNoticedPostContext() { }

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberBanChangedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberBanChangedPostContext.cs
@@ -1,4 +1,5 @@
 ﻿
+using EleCho.GoCqHttpSdk.Post.Interface;
 using EleCho.GoCqHttpSdk.Post.Model;
 using System;
 
@@ -7,7 +8,7 @@ namespace EleCho.GoCqHttpSdk.Post
     /// <summary>
     /// 群成员禁言状态变更上报上下文
     /// </summary>
-    public record class CqGroupMemberBanChangedPostContext : CqNoticePostContext
+    public record class CqGroupMemberBanChangedPostContext : CqNoticePostContext, IGroupPostContext
     {
         /// <summary>
         /// 通知类型: 群禁言
@@ -17,27 +18,27 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 变更类型
         /// </summary>
-        public CqGroupBanChangeType ChangeType { get; set; }
+        public CqGroupBanChangeType ChangeType { get; internal set; }
 
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// 操作者 QQ
         /// </summary>
-        public long OperatorId { get; set; }
+        public long OperatorId { get; internal set; }
 
         /// <summary>
         /// 时长 (如果为 0 则是取消禁言)
         /// </summary>
-        public TimeSpan Duration { get; set; }
+        public TimeSpan Duration { get; internal set; }
 
         internal CqGroupMemberBanChangedPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberDecreasedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberDecreasedPostContext.cs
@@ -1,4 +1,5 @@
 ﻿
+using EleCho.GoCqHttpSdk.Post.Interface;
 using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
@@ -6,7 +7,7 @@ namespace EleCho.GoCqHttpSdk.Post
     /// <summary>
     /// 群成员减少上报上下文
     /// </summary>
-    public record class CqGroupMemberDecreasedPostContext : CqNoticePostContext
+    public record class CqGroupMemberDecreasedPostContext : CqNoticePostContext, IGroupPostContext
     {
         /// <summary>
         /// 通知类型: 群成员减少

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberHonorChangedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberHonorChangedPostContext.cs
@@ -1,4 +1,5 @@
 ﻿
+using EleCho.GoCqHttpSdk.Post.Interface;
 using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
@@ -6,7 +7,7 @@ namespace EleCho.GoCqHttpSdk.Post
     /// <summary>
     /// 群成员群荣誉变更上报上下文
     /// </summary>
-    public record class CqGroupMemberHonorChangedPostContext : CqNotifyNoticePostContext
+    public record class CqGroupMemberHonorChangedPostContext : CqNotifyNoticePostContext, IGroupPostContext
     {
         /// <summary>
         /// 上报类型: 通知
@@ -26,17 +27,17 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 群荣誉类型
         /// </summary>
-        public CqHonorType HonorType { get; set; }
+        public CqHonorType HonorType { get; internal set; }
 
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         internal CqGroupMemberHonorChangedPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberIncreasedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberIncreasedPostContext.cs
@@ -1,4 +1,5 @@
 ﻿
+using EleCho.GoCqHttpSdk.Post.Interface;
 using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
@@ -6,7 +7,7 @@ namespace EleCho.GoCqHttpSdk.Post
     /// <summary>
     /// 群成员增加上报上下文
     /// </summary>
-    public record class CqGroupMemberIncreasedPostContext : CqNoticePostContext
+    public record class CqGroupMemberIncreasedPostContext : CqNoticePostContext, IGroupPostContext
     {
         /// <summary>
         /// 通知类型: 群成员增加
@@ -16,22 +17,22 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 变更类型
         /// </summary>
-        public CqGroupIncreaseChangeType ChangeType { get; set; }
+        public CqGroupIncreaseChangeType ChangeType { get; internal set; }
 
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// 操作者 QQ
         /// </summary>
-        public long OperatorId { get; set; }
+        public long OperatorId { get; internal set; }
 
         internal CqGroupMemberIncreasedPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberNicknameChangedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberNicknameChangedPostContext.cs
@@ -1,4 +1,5 @@
 ﻿
+using EleCho.GoCqHttpSdk.Post.Interface;
 using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
@@ -6,7 +7,7 @@ namespace EleCho.GoCqHttpSdk.Post
     /// <summary>
     /// 群成员群昵称变更上报上下文
     /// </summary>
-    public record class CqGroupMemberNicknameChangedPostContext : CqNoticePostContext
+    public record class CqGroupMemberNicknameChangedPostContext : CqNoticePostContext, IGroupPostContext
     {
         /// <summary>
         /// 通知类型: 
@@ -16,22 +17,22 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// 新昵称
         /// </summary>
-        public string NewNickname { get; set; } = string.Empty;
+        public string NewNickname { get; internal set; } = string.Empty;
 
         /// <summary>
         /// 旧昵称
         /// </summary>
-        public string OldNickname { get; set; } = string.Empty;
+        public string OldNickname { get; internal set; } = string.Empty;
         
         internal CqGroupMemberNicknameChangedPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberTitleChangeNoticedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupMemberTitleChangeNoticedPostContext.cs
@@ -1,4 +1,5 @@
 ﻿
+using EleCho.GoCqHttpSdk.Post.Interface;
 using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
@@ -6,7 +7,7 @@ namespace EleCho.GoCqHttpSdk.Post
     /// <summary>
     /// 群成员头衔变更上报上下文
     /// </summary>
-    public record class CqGroupMemberTitleChangeNoticedPostContext : CqNotifyNoticePostContext
+    public record class CqGroupMemberTitleChangeNoticedPostContext : CqNotifyNoticePostContext, IGroupPostContext
     {
         /// <summary>
         /// 通知类型: 群成员头衔
@@ -16,17 +17,17 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// 新荣誉
         /// </summary>
-        public string NewTitle { get; set; } = string.Empty;
+        public string NewTitle { get; internal set; } = string.Empty;
 
         internal override object? QuickOperationModel => null;
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupMessagePostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupMessagePostContext.cs
@@ -1,5 +1,5 @@
 ﻿using EleCho.GoCqHttpSdk;
-
+using EleCho.GoCqHttpSdk.Post.Interface;
 using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
@@ -7,7 +7,7 @@ namespace EleCho.GoCqHttpSdk.Post
     /// <summary>
     /// 群消息上报上下文
     /// </summary>
-    public record class CqGroupMessagePostContext : CqMessagePostContext
+    public record class CqGroupMessagePostContext : CqMessagePostContext, IGroupPostContext
     {
         /// <summary>
         /// 消息类型: 群
@@ -17,17 +17,12 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 匿名对象
         /// </summary>
-        public CqAnonymousInfomation? Anonymous { get; set; }
-
-        /// <summary>
-        /// 发送者
-        /// </summary>
-        public CqGroupMessageSender Sender { get; set; } = new CqGroupMessageSender();
+        public CqAnonymousInfomation? Anonymous { get; internal set; }
         
         internal CqGroupMessagePostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupMessagePostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupMessagePostContext.cs
@@ -42,7 +42,6 @@ namespace EleCho.GoCqHttpSdk.Post
 
             GroupId = msgModel.group_id;
             Anonymous = msgModel.anonymous == null ? null : new CqAnonymousInfomation(msgModel.anonymous);
-            Sender = new CqGroupMessageSender(msgModel.sender);
         }
     }
 }

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupMessageRecalledPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupMessageRecalledPostContext.cs
@@ -1,4 +1,5 @@
 ﻿
+using EleCho.GoCqHttpSdk.Post.Interface;
 using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
@@ -6,7 +7,7 @@ namespace EleCho.GoCqHttpSdk.Post
     /// <summary>
     /// 群消息撤回上报上下文
     /// </summary>
-    public record class CqGroupMessageRecalledPostContext : CqNoticePostContext
+    public record class CqGroupMessageRecalledPostContext : CqNoticePostContext, IGroupPostContext
     {
         /// <summary>
         /// 通知类型
@@ -16,22 +17,22 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// 操作者 QQ
         /// </summary>
-        public long OperatorId { get; set; }
+        public long OperatorId { get; internal set; }
 
         /// <summary>
         /// 消息 ID
         /// </summary>
-        public long MessageId { get; set; }
+        public long MessageId { get; internal set; }
 
         internal CqGroupMessageRecalledPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupRequestPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupRequestPostContext.cs
@@ -1,11 +1,12 @@
-﻿using EleCho.GoCqHttpSdk.Post.Model;
+﻿using EleCho.GoCqHttpSdk.Post.Interface;
+using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
 {
     /// <summary>
     /// 加群请求上报上下文
     /// </summary>
-    public record class CqGroupRequestPostContext : CqRequestPostContext
+    public record class CqGroupRequestPostContext : CqRequestPostContext, IGroupPostContext
     {
         /// <summary>
         /// 请求类型: 群
@@ -17,27 +18,27 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 群请求类型
         /// </summary>
-        public CqGroupRequestType GroupRequestType { get; set; }
+        public CqGroupRequestType GroupRequestType { get; internal set; }
         
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// 验证消息
         /// </summary>
-        public string Comment { get; set; } = string.Empty;
+        public string Comment { get; internal set; } = string.Empty;
 
         /// <summary>
         /// 加群标志 (用来处理加群请求)
         /// </summary>
-        public string Flag { get; set; } = string.Empty;
+        public string Flag { get; internal set; } = string.Empty;
 
         /// <summary>
         /// 快速操作

--- a/src/EleCho.GoCqHttpSdk/Post/CqGroupSelfMessagePostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqGroupSelfMessagePostContext.cs
@@ -1,11 +1,12 @@
-﻿using EleCho.GoCqHttpSdk.Post.Model;
+﻿using EleCho.GoCqHttpSdk.Post.Interface;
+using EleCho.GoCqHttpSdk.Post.Model;
 
 namespace EleCho.GoCqHttpSdk.Post
 {
     /// <summary>
     /// 群消息上报上下文
     /// </summary>
-    public record class CqGroupSelfMessagePostContext : CqSelfMessagePostContext
+    public record class CqGroupSelfMessagePostContext : CqSelfMessagePostContext, IGroupPostContext
     {
         /// <summary>
         /// 消息类型: 群
@@ -15,17 +16,17 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 群号
         /// </summary>
-        public long GroupId { get; set; }
+        public long GroupId { get; internal set; }
 
         /// <summary>
         /// 匿名对象
         /// </summary>
-        public CqAnonymousInfomation? Anonymous { get; set; }
+        public CqAnonymousInfomation? Anonymous { get; internal set; }
 
         /// <summary>
         /// 发送者
         /// </summary>
-        public CqGroupMessageSender Sender { get; set; } = new CqGroupMessageSender();
+        public CqGroupMessageSender Sender { get; internal set; } = new CqGroupMessageSender();
 
         internal CqGroupSelfMessagePostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqHeartbeatPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqHeartbeatPostContext.cs
@@ -17,12 +17,12 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 状态
         /// </summary>
-        public CqStatus Status { get; set; } = new CqStatus();
+        public CqStatus Status { get; internal set; } = new CqStatus();
 
         /// <summary>
         /// 间隔
         /// </summary>
-        public TimeSpan Interval { get; set; }
+        public TimeSpan Interval { get; internal set; }
         
         internal CqHeartbeatPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqLifecyclePostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqLifecyclePostContext.cs
@@ -16,7 +16,7 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 生命周期类型
         /// </summary>
-        public CqLifecycleType LifecycleType { get; set; }
+        public CqLifecycleType LifecycleType { get; internal set; }
 
         internal CqLifecyclePostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqOfflineFileUploadedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqOfflineFileUploadedPostContext.cs
@@ -17,12 +17,12 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// 离线文件
         /// </summary>
-        public CqOfflineFile File { get; set; } = new CqOfflineFile();
+        public CqOfflineFile File { get; internal set; } = new CqOfflineFile();
         
         internal CqOfflineFileUploadedPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqPokeNoticedPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqPokeNoticedPostContext.cs
@@ -16,22 +16,22 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 群号
         /// </summary>
-        public long? GroupId { get; set; }
+        public long? GroupId { get; internal set; }
 
         /// <summary>
         /// 用户 QQ
         /// </summary>
-        public long UserId { get; set; }
+        public long UserId { get; internal set; }
 
         /// <summary>
         /// 发送者 QQ
         /// </summary>
-        public long SenderId { get; set; }
+        public long SenderId { get; internal set; }
 
         /// <summary>
         /// 目标 QQ
         /// </summary>
-        public long TargetId { get; set; }
+        public long TargetId { get; internal set; }
 
         internal CqPokedPostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqPrivateMessagePostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqPrivateMessagePostContext.cs
@@ -44,7 +44,6 @@ namespace EleCho.GoCqHttpSdk.Post
 
             PrivateMessageType = CqEnum.GetPrivateMessageType(msgModel.sub_type);
             TempSource = (CqTempSource)msgModel.temp_source;
-            Sender = new CqMessageSender(msgModel.sender);
         }
     }
 }

--- a/src/EleCho.GoCqHttpSdk/Post/CqPrivateMessagePostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqPrivateMessagePostContext.cs
@@ -19,17 +19,12 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 消息
         /// </summary>
-        public CqPrivateMessageType PrivateMessageType { get; set; }
+        public CqPrivateMessageType PrivateMessageType { get; internal set; }
 
         /// <summary>
         /// 临时会话来源
         /// </summary>
-        public CqTempSource TempSource { get; set; }
-
-        /// <summary>
-        /// 发送者
-        /// </summary>
-        public CqMessageSender Sender { get; set; } = new CqMessageSender();
+        public CqTempSource TempSource { get; internal set; }
         
         internal CqPrivateMessagePostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/CqPrivateSelfMessagePostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/CqPrivateSelfMessagePostContext.cs
@@ -15,17 +15,17 @@ namespace EleCho.GoCqHttpSdk.Post
         /// <summary>
         /// 消息
         /// </summary>
-        public CqPrivateMessageType PrivateMessageType { get; set; }
+        public CqPrivateMessageType PrivateMessageType { get; internal set; }
 
         /// <summary>
         /// 临时会话来源
         /// </summary>
-        public CqTempSource TempSource { get; set; }
+        public CqTempSource TempSource { get; internal set; }
 
         /// <summary>
         /// 发送者
         /// </summary>
-        public CqMessageSender Sender { get; set; } = new CqMessageSender();
+        public CqMessageSender Sender { get; internal set; } = new CqMessageSender();
 
         internal CqPrivateSelfMessagePostContext() { }
 

--- a/src/EleCho.GoCqHttpSdk/Post/Interface/IGroupPostContext.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/Interface/IGroupPostContext.cs
@@ -1,0 +1,13 @@
+﻿namespace EleCho.GoCqHttpSdk.Post.Interface
+{
+    /// <summary>
+    /// 群聊上报标记（其实就是能读GroupId
+    /// </summary>
+    public interface IGroupPostContext
+    {
+        /// <summary>
+        /// 群号
+        /// </summary>
+        public long GroupId { get; }
+    }
+}

--- a/src/EleCho.GoCqHttpSdk/Post/Model/Base/CqMessagePostModel.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/Model/Base/CqMessagePostModel.cs
@@ -1,6 +1,7 @@
 ﻿#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 #pragma warning disable IDE1006 // Naming Styles
 
+using EleCho.GoCqHttpSdk.DataStructure.Model;
 using EleCho.GoCqHttpSdk.Message.DataModel;
 
 namespace EleCho.GoCqHttpSdk.Post.Model
@@ -16,5 +17,6 @@ namespace EleCho.GoCqHttpSdk.Post.Model
         public CqMsgModel[] message { get; set; }
         public string raw_message { get; set; }
         public int font { get; set; }
+        public CqMessageSenderModel sender { get; set; }
     }
 }

--- a/src/EleCho.GoCqHttpSdk/Post/Model/CqGroupMessagePostModel.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/Model/CqGroupMessagePostModel.cs
@@ -11,6 +11,5 @@ namespace EleCho.GoCqHttpSdk.Post.Model
 
         public long group_id { get; set; }
         public CqAnonymousInformationModel? anonymous { get; set; }
-        public CqGroupMessageSenderModel sender { get; set; }
     }
 }

--- a/src/EleCho.GoCqHttpSdk/Post/Model/CqNoticeEssencePostModel.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/Model/CqNoticeEssencePostModel.cs
@@ -17,5 +17,6 @@ namespace EleCho.GoCqHttpSdk.Post.Model
         public long sender_id { get; set; }
         public long operator_id { get; set; }
         public long message_id { get; set; }
+        public long group_id { get; set; }
     }
 }

--- a/src/EleCho.GoCqHttpSdk/Post/Model/CqPrivateMessagePostModel.cs
+++ b/src/EleCho.GoCqHttpSdk/Post/Model/CqPrivateMessagePostModel.cs
@@ -13,6 +13,5 @@ namespace EleCho.GoCqHttpSdk.Post.Model
         /// <see cref="CqTempSource"/>
         /// </summary>
         public int temp_source { get; set; }
-        public CqMessageSenderModel sender { get; set; }
     }
 }


### PR DESCRIPTION
新的接口：
EleCho.GoCqHttpSdk.Post.Interface.IGroupPostContext：所有群聊上报消息（除了戳一戳）都实现了该接口，可以读取群号
EleCho.GoCqHttpSdk.ICqActionAndPostSession：正向和反向websocket会话实现了这个接口，其实就是ICqPostSession和ICqActionSession
成员变更：CqNoticeEssencePostContext现在实现了GroupId
行为变更：几乎所有上报消息的成员的set访问器都改为了internel set，因为你根本就不应该更改这些内容
其他：
将.net 8.0添加到目标框架
csproj文件的一些清理