### PR TITLE
修复新版本LLOneBot下图片消息中的$.data.subType无法被反序列化为int?类型导致图片消息无法被SDK正常接收的问题

### DIFF
--- a/src/EleCho.GoCqHttpSdk/Message/CqImageMsg.cs
+++ b/src/EleCho.GoCqHttpSdk/Message/CqImageMsg.cs
@@ -148,7 +148,7 @@ namespace EleCho.GoCqHttpSdk.Message
         }
 
         internal override CqMsgDataModel? GetDataModel() =>
-            new CqImageMsgDataModel(Image, ImageTypeToString(ImageType), ((int)ImageSubType).ToString(), Url?.ToString(), UseCache.ToInt(), (int?)ImageEffect, ThreadCount);
+            new CqImageMsgDataModel(Image, ImageTypeToString(ImageType), (int)ImageSubType, Url?.ToString(), UseCache.ToInt(), (int?)ImageEffect, ThreadCount);
 
         internal override void ReadDataModel(CqMsgDataModel? model)
         {
@@ -158,7 +158,7 @@ namespace EleCho.GoCqHttpSdk.Message
 
             Image = m.file;
             ImageType = ImageTypeFromString(m.type);
-            ImageSubType = int.TryParse(m.subType, out int intsubtype) ? (CqImageSubType)intsubtype : CqImageSubType.Normal;
+            ImageSubType = m.subType.HasValue ? (CqImageSubType)m.subType : CqImageSubType.Normal;
             UseCache = m.cache.ToBool();
             ImageEffect = (CqImageEffect?)m.id;
             ThreadCount = m.c;

--- a/src/EleCho.GoCqHttpSdk/Message/DataModel/CqImageMsgDataModel.cs
+++ b/src/EleCho.GoCqHttpSdk/Message/DataModel/CqImageMsgDataModel.cs
@@ -8,7 +8,7 @@ namespace EleCho.GoCqHttpSdk.Message.DataModel
         {
         }
 
-        public CqImageMsgDataModel(string? file, string? type, string? subType, string? url, int? cache, int? id, int? c)
+        public CqImageMsgDataModel(string? file, string? type, int? subType, string? url, int? cache, int? id, int? c)
         {
             this.file = file;
             this.type = type;
@@ -21,7 +21,7 @@ namespace EleCho.GoCqHttpSdk.Message.DataModel
 
         public string? file { get; set; }
         public string? type { get; set; }
-        public string? subType { get; set; }
+        public int? subType { get; set; }
         public string? url { get; set; }
         public int? cache { get; set; }
         public int? id { get; set; }
@@ -32,7 +32,7 @@ namespace EleCho.GoCqHttpSdk.Message.DataModel
             return new CqImageMsgDataModel(
                 code.GetString(nameof(file))!,
                 code.GetString(nameof(type)),
-                code.GetString(nameof(subType)),
+                code.GetInt(nameof(subType)),
                 code.GetString(nameof(url))!,
                 code.GetInt(nameof(cache)),
                 code.GetInt(nameof(id)),


### PR DESCRIPTION
修复新版本LLOneBot下图片消息中的$.data.subType无法被反序列化为int?类型导致图片消息无法被SDK正常接收的问题